### PR TITLE
Upgraded react-document-title version to 2.0.1 to fix "Warning: React…

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 
 Npm.depends({
   'exposify': '0.4.3',
-  'react-document-title': '2.0.0'
+  'react-document-title': '2.0.1'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Fixed the version of react-document-title used in the meteor package, to enjoy the latest update that removes a React warning.